### PR TITLE
Don't fire didFinishPlaying on a nil error

### DIFF
--- a/Sources/AudioPlayer.swift
+++ b/Sources/AudioPlayer.swift
@@ -28,8 +28,8 @@ public final class AudioPlayer: ObservableObject {
 
     public init(
       timeUpdateInterval: CMTime = CMTime(value: 1, timescale: 10),
-      didStartPlaying: @escaping @Sendable () -> Void,
-      didFinishPlaying: @escaping @Sendable () -> Void
+      didStartPlaying: @escaping @Sendable () -> Void = {},
+      didFinishPlaying: @escaping @Sendable () -> Void = {}
     ) {
         self.timeUpdateInterval = timeUpdateInterval
         self.didStartPlaying = didStartPlaying

--- a/Sources/AudioPlayer.swift
+++ b/Sources/AudioPlayer.swift
@@ -117,15 +117,6 @@ public final class AudioPlayer: ObservableObject {
         } onDurationChanged: { [weak self] duration in
             self?.setCurrentDuration(duration)
         } onError: { [weak self] error in
-<<<<<<< HEAD
-            self?.setError(error)
-          self?.didFinishPlaying()
-        } onComplete: { [weak self] in
-            self?.setState(.completed)
-            self?.didFinishPlaying()
-        } onPlaying: { [weak self] in
-            self?.setState(.playing)
-=======
             self?.setCurrentError(error)
             self?.didFinishPlaying()
         } onComplete: { [weak self] in
@@ -133,7 +124,6 @@ public final class AudioPlayer: ObservableObject {
             self?.didFinishPlaying()
         } onPlaying: { [weak self] in
             self?.setCurrentState(.playing)
->>>>>>> upstream/main
             self?.didStartPlaying()
         } onPaused: { [weak self] in
             self?.setCurrentState(.paused)

--- a/Sources/AudioPlayer.swift
+++ b/Sources/AudioPlayer.swift
@@ -102,6 +102,7 @@ public final class AudioPlayer: ObservableObject {
             self?.setTime(time)
         } onError: { [weak self] error in
             self?.setError(error)
+          self?.didFinishPlaying()
         } onComplete: { [weak self] in
             self?.setState(.completed)
             self?.didFinishPlaying()

--- a/Sources/AudioPlayer.swift
+++ b/Sources/AudioPlayer.swift
@@ -118,9 +118,9 @@ public final class AudioPlayer: ObservableObject {
             self?.setCurrentDuration(duration)
         } onError: { [weak self] error in
             self?.setCurrentError(error)
-          if error != nil {
-            self?.didFinishPlaying()
-          }
+            if error != nil {
+              self?.didFinishPlaying()
+            }
         } onComplete: { [weak self] in
             self?.setCurrentState(.completed)
             self?.didFinishPlaying()

--- a/Sources/AudioPlayer.swift
+++ b/Sources/AudioPlayer.swift
@@ -118,7 +118,9 @@ public final class AudioPlayer: ObservableObject {
             self?.setCurrentDuration(duration)
         } onError: { [weak self] error in
             self?.setCurrentError(error)
+          if error != nil {
             self?.didFinishPlaying()
+          }
         } onComplete: { [weak self] in
             self?.setCurrentState(.completed)
             self?.didFinishPlaying()


### PR DESCRIPTION
This prevents `didFinishPlaying` from firing if the observedError is `nil` as reported in https://github.com/mihai8804858/swift-chunked-audio-player/issues/12.