### PR TITLE
Fix playback not starting when connected to AirPlay route

### DIFF
--- a/Sources/AudioSynchronizer.swift
+++ b/Sources/AudioSynchronizer.swift
@@ -180,10 +180,8 @@ final class AudioSynchronizer: @unchecked Sendable {
             if let buffer = audioBuffersQueue.peek(), isBuffering {
                 audioRenderer.enqueue(buffer)
                 audioBuffersQueue.removeFirst()
-                if audioRenderer.hasSufficientMediaDataForReliablePlaybackStart || dataComplete {
-                    audioSynchronizer.setRate(rate, time: audioSynchronizer.currentTime())
-                    isBuffering = false
-                }
+                audioSynchronizer.setRate(rate, time: audioSynchronizer.currentTime())
+                isBuffering = false
             }
         } catch {
             onEvent(.stateChanged(.failed(AudioPlayerError(error: error))))
@@ -225,8 +223,6 @@ final class AudioSynchronizer: @unchecked Sendable {
               let audioSynchronizer,
               audioSynchronizer.rate == 0,
               !didStart else { return }
-        let shouldStart = audioRenderer.hasSufficientMediaDataForReliablePlaybackStart || dataComplete
-        guard shouldStart else { return }
         audioSynchronizer.setRate(rate, time: time)
         didStart = true
         onEvent(.stateChanged(.playing))


### PR DESCRIPTION
If the device is connected to an AirPlay route prior to calling `ChunkedAudioPlayer.AudioPlayer.start` function, playback will not start due to [hasSufficientMediaDataForReliablePlaybackStart](https://developer.apple.com/documentation/avfoundation/avqueuedsamplebufferrendering/hassufficientmediadataforreliableplaybackstart) never becomes `true`. This however is not an issue when the active route is iPhone speaker/wired headphones/AirPods and seems to be AirPlay only.

# Testing proof

Before (Audio doesn't automatically start when connected to home pod):
https://github.com/user-attachments/assets/fe17e21f-229d-48e4-be8e-ef533383017e

After (Now audio can start, just like when connected to iPhone speaker/headphones/AirPods):
https://github.com/user-attachments/assets/fc0e6fb1-686f-4184-a6d4-b722177841d7